### PR TITLE
Maxi repair

### DIFF
--- a/documentary_movie.cpp
+++ b/documentary_movie.cpp
@@ -21,8 +21,8 @@ void Documentary_movie::write(std::ostream& os) const {
 }
 void Documentary_movie::read_from_file(std::ifstream& ifs, char s) {
     char i;
-    ifs >> s;
-    while(ifs >> i && i != s) {
+    ifs >> i;
+    while(ifs.get(i) && i != s) { // a >> leveszi a spaceket, helyette get
         title += i;
     }
     int g;

--- a/family_movie.cpp
+++ b/family_movie.cpp
@@ -21,8 +21,8 @@ void Family_movie::write(std::ostream& os) const {
 }
 void Family_movie::read_from_file(std::ifstream& ifs, char s) {
     char i;
-    ifs >> s;
-    while(ifs >> i && i != s) {
+    ifs >> i;
+    while(ifs.get(i) && i != s) { // a >> leveszi a spaceket, helyette get
         title += i;
     }
     int g;

--- a/library.cpp
+++ b/library.cpp
@@ -7,11 +7,12 @@
 #include "memtrace.h"
 
 size_t Library::size_() const {
-    return size;
+//    return size_;
+    return this->list.size();
 }
 Movie* Library::list_member(size_t i) {
     try {
-        if(size != list.size_()) throw "rossz";
+//        if(size != list.size()) throw "rossz";
         return list[i];
     }
     catch(...) {
@@ -20,11 +21,11 @@ Movie* Library::list_member(size_t i) {
 }
 void Library::add(Movie* new_movie) {
     list.add(new_movie);
-    size++;
+//    size++; // A list elintézi
 }
 void Library::del(Movie* delete_movie) {
     list.del(delete_movie);
-    size--;
+//    size--; // A list elintézi
 }
 void Library::read_from_file(std::ifstream& ifs, char s) {
     char movie_type = ' ';
@@ -49,5 +50,12 @@ void Library::read_from_file(std::ifstream& ifs, char s) {
 void Library::write_to_file(std::ofstream& ofs, char s) {
     for(size_t i = 0; i < size_(); i++) {
         list_member(i)->write_to_file(ofs, ';');
+    }
+}
+
+Library::~Library(){
+    // Memória felszabadítás a library felelőssége, amit a library foglalt le
+    for (int i = 0; i < list.size(); i++){
+        delete list[i];
     }
 }

--- a/library.h
+++ b/library.h
@@ -8,9 +8,10 @@
 
 class Library : public Serializable {
     List<Movie*> list;
-    size_t size;
+//    size_t size = 0; // Nem kell, listának van már
 public:
-    Library() : list(), size(list.size_()) {}
+    Library() : list()/*, size(list.size())*/ {}
+    ~Library();
     size_t size_() const;
     Movie* list_member(size_t i = 0);
     void add(Movie* new_movie);

--- a/list.hpp
+++ b/list.hpp
@@ -9,18 +9,18 @@ class List {
         T data;
         List_member* next;
         List_member() : next(nullptr) {}
-        ~List_member() { delete data; }
+//        ~List_member() { delete data; }
     };
     List_member* first;
-    size_t size;
+    size_t size_; // A külső function neve legyen inkább sima size()
 public:
     List<T>() {
         first = nullptr;
-        size = 0;
+        size_ = 0;
     }
-    size_t size_() { return size; }
+    size_t size() const { return size_; }
     T& operator[](size_t i) {
-        if(i > size) throw std::out_of_range("Tulindexelt.");
+        if(i >= size_) throw std::out_of_range("Tulindexelt.");
         List_member* current = first;
         for(size_t j = 0; j < i; j++) {
             if (current == nullptr)
@@ -32,7 +32,7 @@ public:
     void add(const T dat) {
         List_member* new_node = new List_member;
         new_node->data = dat;
-        new_node->next = nullptr;
+//        new_node->next = nullptr;
         if(first == nullptr)
             first = new_node;
         else {
@@ -42,15 +42,15 @@ public:
             }
             current->next = new_node;
         }
-        new_node->next = nullptr;
-        size++;
+//        new_node->next = nullptr;
+        size_++;
     }
     void del(const T dat) {
         if(first->data == dat) {
             List_member* temp = first->next;
             delete first;
             first = temp;
-            size--;
+            size_--;
             return;
         }
         List_member* current = first->next;
@@ -64,7 +64,7 @@ public:
             prev = current;
             current = current->next;
         }
-        size--;
+        size_--;
     }
     ~List() {
         List_member* current = first;

--- a/menu.h
+++ b/menu.h
@@ -17,11 +17,11 @@ enum Menu_Options {
     LOG_OUT, ADD, EDIT, SEARCH, DELETE, LIST_ALL
 };
 class Menu {
-    Library library;
+    Library& library; // Referencia hiányzott!!!
     std::ostream& out;
     std::istream& in;
 public:
-    Menu(Library l, std::ostream& o = std::cout, std::istream& i = std::cin) : library(l), out(o), in(i) {}
+    Menu(Library& l, std::ostream& o = std::cout, std::istream& i = std::cin) : library(l), out(o), in(i) {}
     bool menu();
     void print_start();
     void print_menu();

--- a/movie.cpp
+++ b/movie.cpp
@@ -57,8 +57,8 @@ void Movie::write(std::ostream& os) const {
 }
 void Movie::read_from_file(std::ifstream& ifs, char s) {
     char i;
-    ifs >> s;
-    while(ifs >> i && i != s) {
+    ifs >> i;
+    while(ifs.get(i) && i != s) { // a >> leveszi a spaceket, helyette get
         title += i;
     }
     int g;


### PR DESCRIPTION
- Fő hiba: Library-t nem referenciaként adtad át a menu-nek - Javítva
- Movei/Family_movie/Documentary_movie fájlb beolvasásnál a >> helyett get(char) használatával nem tűnnek el a whitespace-ek
- list.hpp -ben átneveztem a szite_() fgv-t size()-ra hogy egyértelmű legyen. a belső változónak lehet fura neve, kintinek egyértelmű legyen. --> library-nek nem kell size adattag, hisz a list.size() mindig lekérdezhető
- list_member-ből kivettem a delete data-t hisz ő csak a node-ok felszabadításáért felelés. A lefoglalt plusz adatért a library.
- Ezért a library-nek lett destructora, ami törli a lefoglalt move-kat.

(Minden változtatott helyre raktam kommenetet, utólag majd töröld ki)